### PR TITLE
Implement saved teams feature in MyTeamPage

### DIFF
--- a/frontend/src/pages/MyTeamPage.tsx
+++ b/frontend/src/pages/MyTeamPage.tsx
@@ -1,7 +1,37 @@
+import { useEffect, useState } from "react";
 import { useTeam } from "../context/TeamContext";
+import { useAuth } from "@clerk/clerk-react";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
 export default function MyTeamPage() {
   const { team, removePlayer, registerTeam, isRegistered, resetTeam } = useTeam();
+  const { getToken } = useAuth();
+
+  const [savedTeams, setSavedTeams] = useState<any[]>([]);
+
+  useEffect(() => {
+    const fetchSavedTeams = async () => {
+      try {
+        const token = await getToken();
+
+        const res = await fetch(`${API_URL}/api/user-team`, {
+          headers: {
+            Authorization: `Bearer ${token}`
+          }
+        });
+
+        if (res.ok) {
+          const data = await res.json();
+          setSavedTeams(data);
+        }
+      } catch (error) {
+        console.log("Failed to fetch saved teams");
+      }
+    };
+
+    fetchSavedTeams();
+  }, []);
 
   if (team.length === 0) {
     return <p>Please select players first</p>;
@@ -15,7 +45,7 @@ export default function MyTeamPage() {
         {team.map((player) => (
           <li key={player.id}>
             {player.name} ({player.team})
-            
+
             {!isRegistered && (
               <button onClick={() => removePlayer(player.id)}>
                 Remove
@@ -25,18 +55,34 @@ export default function MyTeamPage() {
         ))}
       </ul>
 
-      {/* REGISTER BUTTON */}
       {!isRegistered ? (
         <button onClick={registerTeam}>
           Register Team
         </button>
       ) : (
         <>
-          <p> Team Registered</p>
+          <p>Team Registered</p>
           <button onClick={resetTeam}>
             Void Team
           </button>
         </>
+      )}
+
+      {/* NEW SAFE FEATURE */}
+      <hr />
+
+      <h3>My Saved Teams</h3>
+
+      {savedTeams.length === 0 ? (
+        <p>No saved teams yet</p>
+      ) : (
+        <ul>
+          {savedTeams.map((t, index) => (
+            <li key={t.id || index}>
+              Team #{index + 1} ({t.players?.length || 0} players)
+            </li>
+          ))}
+        </ul>
       )}
     </section>
   );


### PR DESCRIPTION
Added a small feature to display user-specific saved teams in MyTeamPage.

- Fetches saved teams from backend using authenticated request
- Displays list of saved teams for logged-in user
- Keeps existing functionality unchanged

This improves user experience without affecting existing features.