### PR TITLE
Fix backend dependency for Clerk

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^25.5.0",
     "ts-node-dev": "^2.0.0",
+    "@clerk/express": "^1.7.15",
     "typescript": "^6.0.2"
   }
 }


### PR DESCRIPTION
Added missing @clerk/express dependency required for backend authentication middleware.
This ensures backend can properly verify user sessions using Clerk.